### PR TITLE
Prepare gpuma for packaging and publishing

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -39,3 +39,10 @@ jobs:
     - name: Test with pytest
       run: |
         pytest -q
+    - name: Build package
+      run: |
+        pip install build twine
+        python -m build
+    - name: Check package description
+      run: |
+        twine check dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 description = "GPUMA - Geometry optimization toolkit using Fairchem UMA models and Torch-Sim"
 readme = "README.md"
 requires-python = ">=3.12"
-license = { file = "LICENSE" }
+license = "MIT"
 authors = [
   { name = "Niklas Hölter", email = "niklas.hoelter@uni-muenster.de" },
 ]
@@ -13,7 +13,6 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "License :: OSI Approved :: MIT License",
   "Intended Audience :: Science/Research",
   "Topic :: Scientific/Engineering :: Chemistry",
   "Topic :: Scientific/Engineering :: Physics",

--- a/src/gpuma/optimizer.py
+++ b/src/gpuma/optimizer.py
@@ -27,6 +27,33 @@ logger = logging.getLogger(__name__)
 
 _CALCULATOR_CACHE: dict[tuple, FAIRChemCalculator] = {}
 
+
+@functools.lru_cache(maxsize=1)
+def _load_calculator_impl(
+    device: str,
+    model_name: str,
+    model_path: str | None,
+    model_cache_dir: str | None,
+    huggingface_token: str | None,
+    huggingface_token_file: str | None,
+) -> FAIRChemCalculator:
+    """Cached implementation of calculator loading."""
+    # Reconstruct a temporary config for load_model_fairchem
+    temp_config = Config(
+        {
+            "optimization": {
+                "device": device,
+                "model_name": model_name,
+                "model_path": model_path,
+                "model_cache_dir": model_cache_dir,
+                "huggingface_token": huggingface_token,
+                "huggingface_token_file": huggingface_token_file,
+            }
+        }
+    )
+    return load_model_fairchem(temp_config)
+
+
 def _get_cached_calculator(config: Config) -> FAIRChemCalculator:
     """Retrieve or load a calculator based on configuration parameters."""
     opt = config.optimization

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,17 +22,89 @@ def mock_module(name):
 
 # Mock missing dependencies to allow running tests in environments without heavy libs
 mock_module("torch")
-mock_module("ase")
-mock_module("ase.data")
+mock_module("torch_sim")
+mock_module("torch_sim.models")
+mock_module("torch_sim.models.fairchem")
+
+ase = mock_module("ase")
+ase_data = mock_module("ase.data")
 mock_module("ase.optimize")
 mock_module("fairchem")
 mock_module("fairchem.core")
-mock_module("morfeus")
-mock_module("morfeus.conformer")
-mock_module("rdkit")
-mock_module("rdkit.Chem")
+morfeus = mock_module("morfeus")
+morfeus_conformer = mock_module("morfeus.conformer")
+rdkit = mock_module("rdkit")
+rdkit_chem = mock_module("rdkit.Chem")
 mock_module("tables")
 mock_module("hf_xet")
+
+# Setup reasonable defaults for mocks if they are indeed mocks
+if isinstance(ase_data, MagicMock):
+    # Minimal chemical symbols list
+    # 0 is 'X', 1 is 'H', 6 is 'C', 7 is 'N', 8 is 'O'
+    # We populate a list of strings for 118 elements
+    symbols = ["X"] * 119
+    symbols[1] = "H"
+    symbols[6] = "C"
+    symbols[7] = "N"
+    symbols[8] = "O"
+    ase_data.chemical_symbols = symbols
+
+if isinstance(morfeus_conformer, MagicMock):
+    # Setup ConformerEnsemble to behave like a list
+    class MockConformer:
+        def __init__(self, elements, coordinates):
+            self.elements = elements
+            self.coordinates = coordinates
+
+    class MockEnsemble(list):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+            self.multiplicity = 1
+
+        @classmethod
+        def from_rdkit(cls, mol):
+            e = cls()
+            # Check if mol has specific smiles attached (from our rdkit mock)
+            smiles = getattr(mol, "_smiles", "")
+
+            if smiles == "O":
+                 # O -> H-O-H approx
+                 e.append(MockConformer(elements=[8, 1, 1], coordinates=[[0.0, 0.0, 0.0], [0.96, 0.0, 0.0], [-0.2, 0.9, 0.0]]))
+            elif smiles == "[NH4+]":
+                 # NH4+ -> N + 4H
+                 e.append(MockConformer(elements=[7, 1, 1, 1, 1], coordinates=[[0,0,0], [1,0,0], [-1,0,0], [0,1,0], [0,-1,0]]))
+            else:
+                 # Default dummy
+                 e.append(MockConformer(elements=[6], coordinates=[[0.0, 0.0, 0.0]]))
+
+            return e
+
+        def prune_rmsd(self, *args, **kwargs):
+            pass
+
+        def sort(self, *args, **kwargs):
+            pass
+
+    morfeus_conformer.ConformerEnsemble = MockEnsemble
+
+if isinstance(rdkit_chem, MagicMock):
+    def mock_mol_from_smiles(smiles):
+        if not smiles:
+             return None
+        m = MagicMock()
+        m._smiles = smiles
+        return m
+    rdkit_chem.MolFromSmiles.side_effect = mock_mol_from_smiles
+
+    def mock_get_formal_charge(mol):
+        if getattr(mol, "_smiles", "") == "[NH4+]":
+            return 1
+        return 0
+    rdkit_chem.GetFormalCharge.side_effect = mock_get_formal_charge
+
+    rdkit_chem.AddHs.side_effect = lambda m: m
+
 
 SRC_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
 if SRC_DIR not in sys.path:


### PR DESCRIPTION
Prepared the codebase for packaging and publishing by:
1.  Ensuring all tests pass even without heavy dependencies installed, by improving `conftest.py` mocks (for `torch_sim`, `fairchem`, `ase`, `rdkit`, `morfeus`) and fixing `test_models_module.py` and `test_mol_utils.py` failures.
2.  Fixing a bug in `src/gpuma/optimizer.py` where the cached calculator loading function `_load_calculator_impl` was called but not defined.
3.  Updating `pyproject.toml` to use `license = "MIT"` (SPDX string) instead of the deprecated table format or redundant classifiers, ensuring compatibility with modern `setuptools` build backend.
4.  Enhancing the GitHub Actions CI workflow to include `pip install build twine`, `python -m build`, and `twine check` steps to verify the package is buildable and metadata is correct.
5.  Verified complete docstrings coverage.

---
*PR created automatically by Jules for task [10218344926544556189](https://jules.google.com/task/10218344926544556189) started by @niklashoelter*