### PR TITLE
Parameterize convergence criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ Example (JSON):
     "charge": 0,
     "multiplicity": 1,
 
+    "force_convergence_criterion": 5e-2,
+    "energy_convergence_criterion": null,
+
     "model_name": "uma-m-1p1",
     "model_path": null,
     "model_cache_dir": null,
@@ -196,6 +199,9 @@ optimization:
   charge: 0
   multiplicity: 1
 
+  force_convergence_criterion: 5.0e-2
+  energy_convergence_criterion: null
+
   model_name: uma-m-1p1
   model_path: null
   model_cache_dir: null
@@ -215,6 +221,11 @@ optimization:
 - `charge`: total charge of the system (for SMILES this is inferred from the
   input and not overridden by this setting)
 - `multiplicity`: spin multiplicity of the system
+- `force_convergence_criterion`: force convergence threshold (default: 5e-2).
+  Used for both single and batch optimizations.
+- `energy_convergence_criterion`: energy convergence threshold (default: None).
+  If provided, it is used for batch optimization (unless force is also set).
+  Not supported for single structure optimization.
 - `model_name`: Fairchem UMA model name (e.g., `uma-m-1p1`)
 - `model_path`: local path to a Fairchem UMA model (overrides `model_name` if set)
 - `model_cache_dir`: directory to cache downloaded models (default: `~/.cache/fairchem`)

--- a/examples/config.json
+++ b/examples/config.json
@@ -9,6 +9,9 @@
     "charge": 0,
     "multiplicity": 1,
 
+    "force_convergence_criterion": 5e-2,
+    "energy_convergence_criterion": null,
+
     "model_name": "uma-s-1p1",
     "model_path": null,
     "model_cache_dir": "/mnt/share/models/cache",

--- a/src/gpuma/config.py
+++ b/src/gpuma/config.py
@@ -34,6 +34,9 @@ DEFAULT_CONFIG: dict[str, Any] = {
         # and via config or CLI for SMILES multiplicities.
         "charge": 0,
         "multiplicity": 1,
+        # Convergence criteria
+        "force_convergence_criterion": 5e-2,
+        "energy_convergence_criterion": None,
         "model_name": "uma-s-1p1",
         "model_path": None,
         # Optional local model cache directory; can be overridden by user config
@@ -294,6 +297,30 @@ def validate_config(config: Config) -> None:
         raise ValueError(f"Invalid multiplicity value in config: {multiplicity!r}") from exc
     if mult_int <= 0:
         raise ValueError("Multiplicity must be a positive integer")
+
+    # Convergence criteria
+    force_crit = getattr(opt, "force_convergence_criterion", None)
+    energy_crit = getattr(opt, "energy_convergence_criterion", None)
+
+    if force_crit is not None:
+        try:
+            val = float(force_crit)
+            if val <= 0:
+                raise ValueError
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"force_convergence_criterion must be a positive float, got {force_crit!r}"
+            ) from exc
+
+    if energy_crit is not None:
+        try:
+            val = float(energy_crit)
+            if val <= 0:
+                raise ValueError
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"energy_convergence_criterion must be a positive float, got {energy_crit!r}"
+            ) from exc
 
     # Device must be cpu, cuda or cuda:N
     dev = str(getattr(opt, "device", default_device) or "").strip().lower()

--- a/src/gpuma/optimizer.py
+++ b/src/gpuma/optimizer.py
@@ -133,12 +133,36 @@ def optimize_single_structure(
         atoms.calc = calculator
         atoms.info = {"charge": charge, "spin": multiplicity}
 
+        # Resolve convergence criteria
+        # Single structure optimization only supports force convergence.
+        # If both are given, use force (and warn).
+        # If only energy is given, fallback to force (and warn).
+        force_crit = config.optimization.force_convergence_criterion
+        energy_crit = config.optimization.energy_convergence_criterion
+
+        if force_crit is not None and energy_crit is not None:
+            logger.warning(
+                "Both force and energy convergence criteria given. "
+                "For single structure optimization, the force criterion should be used."
+            )
+            # Use force_crit as is
+        elif force_crit is None and energy_crit is not None:
+            logger.warning(
+                "Energy convergence criterion requested but only force convergence "
+                "criterion can be used for single structure optimization. "
+                "Falling back to default force criterion (0.05)."
+            )
+            force_crit = 0.05
+        elif force_crit is None:
+            # Should not happen with defaults, but safe fallback
+            force_crit = 0.05
+
         logger.info(
             "Starting single geometry optimization for structure with %d atoms",
             len(symbols),
         )
         optimizer = BFGS(atoms, logfile=None)
-        optimizer.run()
+        optimizer.run(fmax=force_crit)
         logger.info(
             "Optimization completed after %d steps",
             optimizer.get_number_of_steps(),
@@ -247,8 +271,24 @@ def _optimize_batch_structures(
         optimizer = torch_sim.Optimizer.fire
     else:
         optimizer = torch_sim.Optimizer.gradient_descent
-    convergence_fn = torch_sim.generate_energy_convergence_fn(energy_tol=1e-6)
-    convergence_fn = torch_sim.generate_force_convergence_fn(force_tol=1e-2)
+
+    # Resolve convergence criteria
+    force_crit = config.optimization.force_convergence_criterion
+    energy_crit = config.optimization.energy_convergence_criterion
+
+    if force_crit is not None and energy_crit is not None:
+        logger.warning(
+            "Both force and energy convergence criteria given. "
+            "Using force convergence criterion."
+        )
+        convergence_fn = torch_sim.generate_force_convergence_fn(force_tol=force_crit)
+    elif force_crit is not None:
+        convergence_fn = torch_sim.generate_force_convergence_fn(force_tol=force_crit)
+    elif energy_crit is not None:
+        convergence_fn = torch_sim.generate_energy_convergence_fn(energy_tol=energy_crit)
+    else:
+        # Fallback to default force criterion if neither is set (unlikely with defaults)
+        convergence_fn = torch_sim.generate_force_convergence_fn(force_tol=0.05)
 
     ase_structures = [
         Atoms(

--- a/tests/test_convergence_criteria.py
+++ b/tests/test_convergence_criteria.py
@@ -1,0 +1,187 @@
+
+import logging
+from unittest.mock import MagicMock, patch, ANY
+import pytest
+import numpy as np
+
+from gpuma.config import Config, DEFAULT_CONFIG, validate_config
+from gpuma.optimizer import optimize_single_structure, _optimize_batch_structures
+from gpuma.structure import Structure
+
+def test_default_config_convergence_criteria():
+    """Test that default configuration has correct convergence criteria values."""
+    assert "force_convergence_criterion" in DEFAULT_CONFIG["optimization"]
+    assert "energy_convergence_criterion" in DEFAULT_CONFIG["optimization"]
+    assert DEFAULT_CONFIG["optimization"]["force_convergence_criterion"] == 0.05
+    assert DEFAULT_CONFIG["optimization"]["energy_convergence_criterion"] is None
+
+def test_validate_config_convergence_criteria():
+    """Test validation of convergence criteria."""
+    cfg = Config()
+    # These should be valid
+    cfg.optimization.force_convergence_criterion = 0.01
+    cfg.optimization.energy_convergence_criterion = None
+    validate_config(cfg)
+
+    cfg.optimization.force_convergence_criterion = None
+    cfg.optimization.energy_convergence_criterion = 1e-6
+    validate_config(cfg)
+
+    # Invalid values
+    cfg.optimization.force_convergence_criterion = -1.0
+    with pytest.raises(ValueError):
+        validate_config(cfg)
+
+    cfg.optimization.force_convergence_criterion = 0.05
+    cfg.optimization.energy_convergence_criterion = -1.0
+    with pytest.raises(ValueError):
+        validate_config(cfg)
+
+def test_optimize_single_structure_uses_force_criterion():
+    """Test that optimize_single_structure uses the configured force criterion."""
+    s = Structure(["H"], [(0.0, 0.0, 0.0)], charge=0, multiplicity=1)
+    cfg = Config()
+    cfg.optimization.force_convergence_criterion = 0.02
+    cfg.optimization.energy_convergence_criterion = None
+
+    # Mock Calculator and Atoms
+    mock_atoms_instance = MagicMock()
+    mock_atoms_instance.get_positions.return_value = np.array([[0.0, 0.0, 0.0]])
+    mock_atoms_instance.get_potential_energy.return_value = -1.0
+
+    with (
+        patch("gpuma.optimizer.Atoms", return_value=mock_atoms_instance),
+        patch("gpuma.optimizer.BFGS") as MockBFGS,
+        patch("gpuma.optimizer._get_cached_calculator")
+    ):
+        mock_bfgs_instance = MockBFGS.return_value
+
+        optimize_single_structure(s, config=cfg)
+
+        # Verify BFGS.run was called with fmax=0.02
+        mock_bfgs_instance.run.assert_called_with(fmax=0.02)
+
+def test_optimize_single_structure_warning_for_energy_criterion(caplog):
+    """Test that single structure optimization warns if energy criterion is requested."""
+    s = Structure(["H"], [(0.0, 0.0, 0.0)], charge=0, multiplicity=1)
+    cfg = Config()
+    cfg.optimization.force_convergence_criterion = None
+    cfg.optimization.energy_convergence_criterion = 1e-5
+
+    mock_atoms_instance = MagicMock()
+    mock_atoms_instance.get_positions.return_value = np.array([[0.0, 0.0, 0.0]])
+    mock_atoms_instance.get_potential_energy.return_value = -1.0
+
+    with (
+        patch("gpuma.optimizer.Atoms", return_value=mock_atoms_instance),
+        patch("gpuma.optimizer.BFGS") as MockBFGS,
+        patch("gpuma.optimizer._get_cached_calculator")
+    ):
+        mock_bfgs_instance = MockBFGS.return_value
+
+        with caplog.at_level(logging.WARNING):
+            optimize_single_structure(s, config=cfg)
+
+        # Should warn about falling back to force
+        assert "only force convergence criterion can be used" in caplog.text.lower()
+        # Should use default force 0.05
+        mock_bfgs_instance.run.assert_called_with(fmax=0.05)
+
+def test_optimize_single_structure_warning_both_criteria(caplog):
+    """Test warning when both criteria are set for single structure."""
+    s = Structure(["H"], [(0.0, 0.0, 0.0)], charge=0, multiplicity=1)
+    cfg = Config()
+    cfg.optimization.force_convergence_criterion = 0.03
+    cfg.optimization.energy_convergence_criterion = 1e-4
+
+    mock_atoms_instance = MagicMock()
+    mock_atoms_instance.get_positions.return_value = np.array([[0.0, 0.0, 0.0]])
+    mock_atoms_instance.get_potential_energy.return_value = -1.0
+
+    with (
+        patch("gpuma.optimizer.Atoms", return_value=mock_atoms_instance),
+        patch("gpuma.optimizer.BFGS") as MockBFGS,
+        patch("gpuma.optimizer._get_cached_calculator")
+    ):
+        mock_bfgs_instance = MockBFGS.return_value
+
+        with caplog.at_level(logging.WARNING):
+            optimize_single_structure(s, config=cfg)
+
+        # Should warn that force is used
+        assert "force criterion should be used" in caplog.text.lower()
+        mock_bfgs_instance.run.assert_called_with(fmax=0.03)
+
+def test_batch_structure_optimization_criteria(caplog):
+    """Test batch optimization criteria selection logic."""
+    s = Structure(["H"], [(0.0, 0.0, 0.0)], charge=0, multiplicity=1)
+    cfg = Config()
+    cfg.optimization.batch_optimization_mode = "batch"
+    cfg.optimization.device = "cuda"
+
+    # Common mocks
+    mock_ts = MagicMock()
+    mock_ts_autobatching = MagicMock()
+    mock_torch = MagicMock()
+
+    # Setup mocks for torch_sim convergence functions
+    mock_energy_conv_fn = MagicMock(name="energy_conv_fn")
+    mock_force_conv_fn = MagicMock(name="force_conv_fn")
+    mock_ts.generate_energy_convergence_fn.return_value = mock_energy_conv_fn
+    mock_ts.generate_force_convergence_fn.return_value = mock_force_conv_fn
+
+    # Mock return values for optimization
+    mock_final_state = MagicMock()
+    mock_final_state.to_atoms.return_value = []
+    mock_ts.optimize.return_value = mock_final_state
+
+    # Mock batched state n_atoms
+    mock_batched_state = MagicMock()
+    mock_batched_state.n_atoms = 10
+    mock_ts.io.atoms_to_state.return_value = mock_batched_state
+
+    modules_to_patch = {
+        "torch_sim": mock_ts,
+        "torch_sim.autobatching": mock_ts_autobatching,
+        "torch": mock_torch
+    }
+
+    with (
+        patch("gpuma.optimizer._parse_device_string", return_value="cuda"),
+        patch("gpuma.optimizer._device_for_torch"),
+        patch("gpuma.optimizer._get_cached_torchsim_model"),
+        patch.dict("sys.modules", modules_to_patch)
+    ):
+        # Case 1: Force only (should use force)
+        cfg.optimization.force_convergence_criterion = 0.02
+        cfg.optimization.energy_convergence_criterion = None
+        _optimize_batch_structures([s], config=cfg)
+        mock_ts.generate_force_convergence_fn.assert_called_with(force_tol=0.02)
+        mock_ts.optimize.assert_called_with(
+            system=ANY, model=ANY, optimizer=ANY,
+            convergence_fn=mock_force_conv_fn, # Check correct fn used
+            autobatcher=ANY, steps_between_swaps=ANY
+        )
+
+        # Case 2: Energy only (should use energy)
+        cfg.optimization.force_convergence_criterion = None
+        cfg.optimization.energy_convergence_criterion = 1e-5
+        _optimize_batch_structures([s], config=cfg)
+        mock_ts.generate_energy_convergence_fn.assert_called_with(energy_tol=1e-5)
+        mock_ts.optimize.assert_called_with(
+            system=ANY, model=ANY, optimizer=ANY,
+            convergence_fn=mock_energy_conv_fn, # Check correct fn used
+            autobatcher=ANY, steps_between_swaps=ANY
+        )
+
+        # Case 3: Both (should use force and warn)
+        cfg.optimization.force_convergence_criterion = 0.03
+        cfg.optimization.energy_convergence_criterion = 1e-4
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            _optimize_batch_structures([s], config=cfg)
+
+        assert "using force convergence criterion" in caplog.text.lower()
+        mock_ts.generate_force_convergence_fn.assert_called_with(force_tol=0.03)
+        # Should be called with force fn
+        mock_ts.optimize.call_args[1]["convergence_fn"] == mock_force_conv_fn


### PR DESCRIPTION
Implemented parameterization of convergence functions as requested.
- Defaults: Force 0.05, Energy None.
- Priority: Force > Energy.
- Warnings: Issued when both are set or when energy is requested for single structure optimization.
- Config: Added `force_convergence_criterion` and `energy_convergence_criterion` keys.

---
*PR created automatically by Jules for task [12337392020986584388](https://jules.google.com/task/12337392020986584388) started by @niklashoelter*