### PR TITLE
Refactor documentation structure and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ uv pip install .
 pip install .
 ```
 
+## Documentation
+
+Full documentation is available at [https://GloriusGroup.github.io/gpuma/](https://GloriusGroup.github.io/gpuma/).
+
+Please refer to the documentation for detailed configuration options and advanced usage. Using a configuration file is highly recommended for reproducibility and ease of use.
+
 ## CLI Usage
 
 The CLI is provided via the command `gpuma`. For best results, create a
@@ -158,98 +164,6 @@ s: Structure = gpuma.smiles_to_xyz("CCO")
 opt_s: Structure = gpuma.optimize_single_structure(s, cfg)
 gpuma.save_xyz_file(opt_s, "examples/example_output/ethanol_opt.xyz")
 ```
-
-## Configuration
-
-All supported parameters live under the `optimization` key. Only these parameters are effective in the code; unknown fields are preserved.
-
-**Always use a config file for CLI and API calls.**
-
-Example (JSON):
-
-```json
-{
-  "optimization": {
-    "batch_optimization_mode": "batch",
-    "batch_optimizer": "fire",
-    "max_num_conformers": 20,
-    "conformer_seed": 42,
-
-    "charge": 0,
-    "multiplicity": 1,
-
-    "force_convergence_criterion": 5e-2,
-    "energy_convergence_criterion": null,
-
-    "model_name": "uma-m-1p1",
-    "model_path": null,
-    "model_cache_dir": null,
-    "device": "cuda",
-    "huggingface_token": null,
-    "huggingface_token_file": "/home/hf_secret",
-
-    "logging_level": "INFO"
-  }
-}
-```
-
-Example (YAML):
-
-```yaml
-optimization:
-  batch_optimization_mode: batch
-  batch_optimizer: fire
-  max_num_conformers: 20
-  conformer_seed: 42
-
-  charge: 0
-  multiplicity: 1
-
-  force_convergence_criterion: 5.0e-2
-  energy_convergence_criterion: null
-
-  model_name: uma-m-1p1
-  model_path: null
-  model_cache_dir: null
-  device: cuda
-  huggingface_token: null
-  huggingface_token_file: /home/hf_secret
-
-  logging_level: INFO
-```
-
-- `batch_optimization_mode`: controls the ensemble mode
-  - `sequential`: ASE/BFGS per conformer with a shared calculator
-  - `batch`: torch-sim batch optimization (accelerated for larger ensembles)
-- `batch_optimizer`: optimizer for batch mode; `fire` (default) or `gradient_descent`
-- `max_num_conformers`: max number of conformers to generate from SMILES (if applicable)
-- `conformer_seed`: random seed for conformer generation (if applicable)
-- `charge`: total charge of the system (for SMILES this is inferred from the
-  input and not overridden by this setting)
-- `multiplicity`: spin multiplicity of the system
-- `force_convergence_criterion`: force convergence threshold (default: 5e-2).
-  Used for both single and batch optimizations.
-- `energy_convergence_criterion`: energy convergence threshold (default: None).
-  If provided, it is used for batch optimization (unless force is also set).
-  Not supported for single structure optimization.
-- `model_name`: Fairchem UMA model name (e.g., `uma-m-1p1`)
-- `model_path`: local path to a Fairchem UMA model (overrides `model_name` if set)
-- `model_cache_dir`: directory to cache downloaded models (default: `~/.cache/fairchem`)
-- `device`: compute device string; one of `cpu` or `cuda`.
-  Fairchem only distinguishes between CPU and CUDA; selection of specific
-  GPUs should be handled via the `CUDA_VISIBLE_DEVICES` environment variable
-  before running the CLI or Python code.
-
-- `huggingface_token`: optional HF token for model access (if required)
-- `huggingface_token_file`: optional file path to read the HF token from
-- `logging_level`: logging verbosity; e.g., `DEBUG`, `INFO`, `WARNING`
-
-See the `examples/` folder for:
-- Simple single optimization (`example_single_optimization.py`)
-- Ensemble optimization from SMILES, multi-XYZ, directories (`example_ensemble_optimization.py`)
-- CLI examples (`example_cli_usage.py`)
-
-The example configs are sanitized (no tokens in plain text).
 
 ## Known limitations
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,91 @@
+# Configuration
+
+All supported parameters live under the `optimization` key. Only these parameters are effective in the code; unknown fields are preserved.
+
+**Always use a config file for CLI and API calls.**
+
+Example (JSON):
+
+```json
+{
+  "optimization": {
+    "batch_optimization_mode": "batch",
+    "batch_optimizer": "fire",
+    "max_num_conformers": 20,
+    "conformer_seed": 42,
+
+    "charge": 0,
+    "multiplicity": 1,
+
+    "force_convergence_criterion": 5e-2,
+    "energy_convergence_criterion": null,
+
+    "model_name": "uma-m-1p1",
+    "model_path": null,
+    "model_cache_dir": null,
+    "device": "cuda",
+    "huggingface_token": null,
+    "huggingface_token_file": "/home/hf_secret",
+
+    "logging_level": "INFO"
+  }
+}
+```
+
+Example (YAML):
+
+```yaml
+optimization:
+  batch_optimization_mode: batch
+  batch_optimizer: fire
+  max_num_conformers: 20
+  conformer_seed: 42
+
+  charge: 0
+  multiplicity: 1
+
+  force_convergence_criterion: 5.0e-2
+  energy_convergence_criterion: null
+
+  model_name: uma-m-1p1
+  model_path: null
+  model_cache_dir: null
+  device: cuda
+  huggingface_token: null
+  huggingface_token_file: /home/hf_secret
+
+  logging_level: INFO
+```
+
+- `batch_optimization_mode`: controls the ensemble mode
+  - `sequential`: ASE/BFGS per conformer with a shared calculator
+  - `batch`: torch-sim batch optimization (accelerated for larger ensembles)
+- `batch_optimizer`: optimizer for batch mode; `fire` (default) or `gradient_descent`
+- `max_num_conformers`: max number of conformers to generate from SMILES (if applicable)
+- `conformer_seed`: random seed for conformer generation (if applicable)
+- `charge`: total charge of the system (for SMILES this is inferred from the
+  input and not overridden by this setting)
+- `multiplicity`: spin multiplicity of the system
+- `force_convergence_criterion`: force convergence threshold (default: 5e-2).
+  Used for both single and batch optimizations.
+- `energy_convergence_criterion`: energy convergence threshold (default: None).
+  If provided, it is used for batch optimization (unless force is also set).
+  Not supported for single structure optimization.
+- `model_name`: Fairchem UMA model name (e.g., `uma-m-1p1`)
+- `model_path`: local path to a Fairchem UMA model (overrides `model_name` if set)
+- `model_cache_dir`: directory to cache downloaded models (default: `~/.cache/fairchem`)
+- `device`: compute device string; one of `cpu` or `cuda`.
+  Fairchem only distinguishes between CPU and CUDA; selection of specific
+  GPUs should be handled via the `CUDA_VISIBLE_DEVICES` environment variable
+  before running the CLI or Python code.
+
+- `huggingface_token`: optional HF token for model access (if required)
+- `huggingface_token_file`: optional file path to read the HF token from
+- `logging_level`: logging verbosity; e.g., `DEBUG`, `INFO`, `WARNING`
+
+See the `examples/` folder for:
+- Simple single optimization (`example_single_optimization.py`)
+- Ensemble optimization from SMILES, multi-XYZ, directories (`example_ensemble_optimization.py`)
+- CLI examples (`example_cli_usage.py`)
+
+The example configs are sanitized (no tokens in plain text).

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,23 @@
+# Installation
+
+## Option 1: Install from PyPI (recommended)
+
+```bash
+pip install gpuma
+```
+
+This installs `gpuma` together with its core dependencies. Make sure you are using
+Python 3.12 or newer.
+
+## Option 2: Install from source
+
+```bash
+# clone the repository
+git clone https://github.com/niklashoelter/gpuma.git
+cd gpuma
+
+# install using (uv) pip
+uv pip install .
+# or, without uv:
+pip install .
+```


### PR DESCRIPTION
This change overworks the README and documentation structure as requested:
-   **Installation**: Duplicated instructions from `README.md` to `docs/install.md` (headers adjusted).
-   **Configuration**: Moved the entire configuration explanation from `README.md` to `docs/config.md` (headers adjusted). Removed the section from `README.md`.
-   **README.md**: Added a new "Documentation" section after "Installation" with a link to the GitHub Pages site and an explicit hint about the importance of reading the docs and using a configuration file.
-   **Structure**: Ensured header levels in `docs/` files are appropriate for top-level pages.

---
*PR created automatically by Jules for task [7633456964763015160](https://jules.google.com/task/7633456964763015160) started by @niklashoelter*